### PR TITLE
[Mellanox] platform: Enable cache on init

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/platform.py
@@ -23,6 +23,7 @@
 
 try:
     from sonic_platform_base.platform_base import PlatformBase
+    from sonic_platform_base.sonic_xcvr.api.public.cmis import CmisApi
     from .chassis import Chassis, ModularChassis, SmartSwitchChassis
     from .device_data import DeviceDataManager
 except ImportError as e:
@@ -31,6 +32,7 @@ except ImportError as e:
 class Platform(PlatformBase):
     def __init__(self):
         PlatformBase.__init__(self)
+        CmisApi.set_cache_enabled(True)
         if DeviceDataManager.get_dpu_count():
             self._chassis = SmartSwitchChassis()
         elif DeviceDataManager.get_linecard_count() == 0:


### PR DESCRIPTION
Depends on: https://github.com/sonic-net/sonic-platform-common/pull/562

Set cache enabled flag.

#### Why I did it
Centralize the XCVR cache enablement logic in the Mellanox platform API so that CMIS cache is configured automatically at Platform initialization for Nvidia platform.

#### How I did it
In Platform.__init__, call CmisApi.set_cache_enabled(True) to set as cache_enabled in cmis.

#### How to verify it
Build and deploy the updated platform daemon package.

#### Which release branch to backport (provide reason below if selected)
- [x] 202411
- [x] 202412

#### Tested branch (Please provide the tested image version)
master.637-eafe0ccb9_Internal