### PR TITLE
Extend router types BackendLeafRouter and BackendToRRouter

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_defaults_objects.j2
@@ -45,14 +45,14 @@
         {%- for port in PORT_ACTIVE %}
             {%- if DEVICE_NEIGHBOR.get(port) and DEVICE_NEIGHBOR[port].name is defined and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA %}
                 {%- set neighbor_info = DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name] %}
-                {%- if local_router_type == 'LeafRouter' %}
-                    {%- if neighbor_info.type == 'ToRRouter' %}
+                {%- if 'LeafRouter' in local_router_type %}
+                    {%- if 'ToRRouter' in neighbor_info.type %}
                         {%- if PORT_DOWNLINK.append(port) %}{%- endif %}
-                    {%- elif neighbor_info.type == 'SpineRouter' %}
+                    {%- elif 'SpineRouter' in neighbor_info.type %}
                         {%- if PORT_UPLINK.append(port) %}{%- endif %}
                     {%- endif %}
-                {%- elif local_router_type == 'ToRRouter' %}
-                    {%- if neighbor_info.type == 'LeafRouter' %}
+                {%- elif 'ToRRouter' in local_router_type %}
+                    {%- if 'LeafRouter' in neighbor_info.type %}
                         {%- if PORT_UPLINK.append(port) %}{%- endif %}
                     {%- else %}
                         {%- if PORT_DOWNLINK.append(port) %}{%- endif %}

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/qos.json.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/qos.json.j2
@@ -205,10 +205,10 @@
         else 'ToRRouter'
     ) %}
 
-    {%- if router_type == 'ToRRouter' %}
+    {%- if 'ToRRouter' in router_type %}
         {# ToR Router thresholds - only override if different from defaults #}
         {%- set max_threshold = "282624" %}
-    {%- elif router_type == 'LeafRouter' %}
+    {%- elif 'LeafRouter' in router_type %}
         {# Leaf Router thresholds - only override if different from defaults #}
         {%- set max_threshold = "239616" %}
     {%- endif %}
@@ -399,14 +399,14 @@
 {%- if traffic_config.traffic_classification_enable %}
     "TC_TO_DSCP_MAP": {
         {% if 'type' in DEVICE_METADATA['localhost'] %}
-            {%- if DEVICE_METADATA['localhost']['type'] == 'ToRRouter' -%}
+            {%- if 'ToRRouter' in DEVICE_METADATA['localhost']['type'] -%}
                 "AZURE_DOWNLINK_BT0": {
                     "8": "21"
                 },
                 "AZURE_UPLINK_BT0": {
                     "8": "11"
                 }
-            {%- elif DEVICE_METADATA['localhost']['type'] == 'LeafRouter' -%}
+            {%- elif 'LeafRouter' in DEVICE_METADATA['localhost']['type'] -%}
                 "AZURE_DOWNLINK_BT1": {
                     "8": "11"
                 }
@@ -424,13 +424,13 @@
             "pfc_enable"      : "",
             "pfcwd_sw_enable" : "",
             {% if traffic_config.traffic_classification_enable %}
-                {% if direction == 'downlink' and DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
+                {% if direction == 'downlink' and 'ToRRouter' in DEVICE_METADATA['localhost']['type'] %}
                     "tc_to_pg_map": "AZURE",
                     "tc_to_dscp_map": "AZURE_DOWNLINK_BT0"
-                {% elif direction == 'uplink' and DEVICE_METADATA['localhost']['type'] == 'ToRRouter' %}
+                {% elif direction == 'uplink' and 'ToRRouter' in DEVICE_METADATA['localhost']['type'] %}
                     "tc_to_pg_map": "AZURE",
                     "tc_to_dscp_map": "AZURE_UPLINK_BT0"
-                {% elif direction == 'downlink' and DEVICE_METADATA['localhost']['type'] == 'LeafRouter' %}
+                {% elif direction == 'downlink' and 'LeafRouter' in DEVICE_METADATA['localhost']['type'] %}
                     "tc_to_pg_map": "AZURE",
                     "tc_to_dscp_map": "AZURE_DOWNLINK_BT1"
                 {% else %}

--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -203,8 +203,8 @@ def
 {%- set port_names_list_extra_queues = [] %}
 {%- for port in PORT_ACTIVE %}
     {%- if ((SYSTEM_DEFAULTS is defined) and ('tunnel_qos_remap' in SYSTEM_DEFAULTS) and (SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled')) and
-            (('type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'LeafRouter' and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type == 'ToRRouter') or
-            ('subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type == 'LeafRouter')) %}
+            (('type' in DEVICE_METADATA['localhost'] and 'LeafRouter' in DEVICE_METADATA['localhost']['type'] and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and 'ToRRouter' in DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type) or
+            ('subtype' in DEVICE_METADATA['localhost'] and 'DualToR' in DEVICE_METADATA['localhost']['subtype'] and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and 'LeafRouter' in DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type)) %}
         {%- if port_names_list_extra_queues.append(port) %}{%- endif %}
     {%- endif %}
 {%- endfor %}

--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -204,7 +204,7 @@ def
 {%- for port in PORT_ACTIVE %}
     {%- if ((SYSTEM_DEFAULTS is defined) and ('tunnel_qos_remap' in SYSTEM_DEFAULTS) and (SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled')) and
             (('type' in DEVICE_METADATA['localhost'] and 'LeafRouter' in DEVICE_METADATA['localhost']['type'] and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and 'ToRRouter' in DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type) or
-            ('subtype' in DEVICE_METADATA['localhost'] and 'DualToR' in DEVICE_METADATA['localhost']['subtype'] and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and 'LeafRouter' in DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type)) %}
+            ('subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and 'LeafRouter' in DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type)) %}
         {%- if port_names_list_extra_queues.append(port) %}{%- endif %}
     {%- endif %}
 {%- endfor %}

--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -203,8 +203,8 @@ def
 {%- set port_names_list_extra_queues = [] %}
 {%- for port in PORT_ACTIVE %}
     {%- if ((SYSTEM_DEFAULTS is defined) and ('tunnel_qos_remap' in SYSTEM_DEFAULTS) and (SYSTEM_DEFAULTS['tunnel_qos_remap']['status'] == 'enabled')) and
-            (('type' in DEVICE_METADATA['localhost'] and 'LeafRouter' in DEVICE_METADATA['localhost']['type'] and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and 'ToRRouter' in DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type) or
-            ('subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and 'LeafRouter' in DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type)) %}
+            (('type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'LeafRouter' and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type == 'ToRRouter') or
+            ('subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type == 'LeafRouter')) %}
         {%- if port_names_list_extra_queues.append(port) %}{%- endif %}
     {%- endif %}
 {%- endfor %}

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -71,14 +71,14 @@
         {%- for port in PORT_ACTIVE %}
             {%- if DEVICE_NEIGHBOR.get(port) and DEVICE_NEIGHBOR[port].name is defined and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA %}
                 {%- set neighbor_info = DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name] %}
-                {%- if local_router_type == 'LeafRouter' %}
-                    {%- if neighbor_info.type == 'ToRRouter' %}
+                {%- if 'LeafRouter' in local_router_type %}
+                    {%- if 'ToRRouter' in neighbor_info.type %}
                         {%- if PORT_DOWNLINK.append(port) %}{%- endif %}
-                    {%- elif neighbor_info.type == 'SpineRouter' %}
+                    {%- elif 'SpineRouter' in neighbor_info.type %}
                         {%- if PORT_UPLINK.append(port) %}{%- endif %}
                     {%- endif %}
-                {%- elif local_router_type == 'ToRRouter' %}
-                    {%- if neighbor_info.type == 'LeafRouter' %}
+                {%- elif 'ToRRouter' in local_router_type %}
+                    {%- if 'LeafRouter' in neighbor_info.type %}
                         {%- if PORT_UPLINK.append(port) %}{%- endif %}
                     {%- else %}
                         {%- if PORT_DOWNLINK.append(port) %}{%- endif %}
@@ -112,8 +112,8 @@
 {%- set port_names_list_extra_queues = [] %}
 {%- for port in PORT_ACTIVE %}
 {% if ((generate_dscp_to_tc_map is defined) and tunnel_qos_remap_enable) and 
-(('type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'LeafRouter' and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type == 'ToRRouter') or
-('subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type == 'LeafRouter')) %}
+(('type' in DEVICE_METADATA['localhost'] and 'LeafRouter' in DEVICE_METADATA['localhost']['type'] and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and 'ToRRouter' in DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type) or
+('subtype' in DEVICE_METADATA['localhost'] and 'DualToR' in DEVICE_METADATA['localhost']['subtype'] and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and 'LeafRouter' in DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type)) %}
         {%- if port_names_list_extra_queues.append(port) %}{%- endif %}
 {% endif %}
 {%- endfor %}
@@ -401,9 +401,9 @@
 {% else %}
 {# Apply separated DSCP_TO_TC_MAP to uplink ports on ToR and Leaf #}
 {% if different_dscp_to_tc_map and tunnel_qos_remap_enable %}
-{% if ('type' in DEVICE_METADATA['localhost']) and (DEVICE_METADATA['localhost']['type'] == 'LeafRouter') and (port not in port_names_list_extra_queues) %}
+{% if ('type' in DEVICE_METADATA['localhost']) and ('LeafRouter' in DEVICE_METADATA['localhost']['type']) and (port not in port_names_list_extra_queues) %}
             "dscp_to_tc_map"  : "AZURE_UPLINK",
-{% elif ('subtype' in DEVICE_METADATA['localhost']) and (DEVICE_METADATA['localhost']['subtype'] == 'DualToR') and (port in port_names_list_extra_queues) %}
+{% elif ('subtype' in DEVICE_METADATA['localhost']) and ('DualToR' in DEVICE_METADATA['localhost']['subtype']) and (port in port_names_list_extra_queues) %}
             "dscp_to_tc_map"  : "AZURE_UPLINK",
 {% else %}
             "dscp_to_tc_map"  : "AZURE",

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -112,8 +112,8 @@
 {%- set port_names_list_extra_queues = [] %}
 {%- for port in PORT_ACTIVE %}
 {% if ((generate_dscp_to_tc_map is defined) and tunnel_qos_remap_enable) and 
-(('type' in DEVICE_METADATA['localhost'] and 'LeafRouter' in DEVICE_METADATA['localhost']['type'] and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and 'ToRRouter' in DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type) or
-('subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and 'LeafRouter' in DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type)) %}
+(('type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] == 'LeafRouter' and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type == 'ToRRouter') or
+('subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type == 'LeafRouter')) %}
         {%- if port_names_list_extra_queues.append(port) %}{%- endif %}
 {% endif %}
 {%- endfor %}
@@ -401,7 +401,7 @@
 {% else %}
 {# Apply separated DSCP_TO_TC_MAP to uplink ports on ToR and Leaf #}
 {% if different_dscp_to_tc_map and tunnel_qos_remap_enable %}
-{% if ('type' in DEVICE_METADATA['localhost']) and ('LeafRouter' in DEVICE_METADATA['localhost']['type']) and (port not in port_names_list_extra_queues) %}
+{% if ('type' in DEVICE_METADATA['localhost']) and (DEVICE_METADATA['localhost']['type'] == 'LeafRouter') and (port not in port_names_list_extra_queues) %}
             "dscp_to_tc_map"  : "AZURE_UPLINK",
 {% elif ('subtype' in DEVICE_METADATA['localhost']) and (DEVICE_METADATA['localhost']['subtype'] == 'DualToR') and (port in port_names_list_extra_queues) %}
             "dscp_to_tc_map"  : "AZURE_UPLINK",

--- a/files/build_templates/qos_config.j2
+++ b/files/build_templates/qos_config.j2
@@ -113,7 +113,7 @@
 {%- for port in PORT_ACTIVE %}
 {% if ((generate_dscp_to_tc_map is defined) and tunnel_qos_remap_enable) and 
 (('type' in DEVICE_METADATA['localhost'] and 'LeafRouter' in DEVICE_METADATA['localhost']['type'] and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and 'ToRRouter' in DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type) or
-('subtype' in DEVICE_METADATA['localhost'] and 'DualToR' in DEVICE_METADATA['localhost']['subtype'] and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and 'LeafRouter' in DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type)) %}
+('subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA and 'LeafRouter' in DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name].type)) %}
         {%- if port_names_list_extra_queues.append(port) %}{%- endif %}
 {% endif %}
 {%- endfor %}
@@ -403,7 +403,7 @@
 {% if different_dscp_to_tc_map and tunnel_qos_remap_enable %}
 {% if ('type' in DEVICE_METADATA['localhost']) and ('LeafRouter' in DEVICE_METADATA['localhost']['type']) and (port not in port_names_list_extra_queues) %}
             "dscp_to_tc_map"  : "AZURE_UPLINK",
-{% elif ('subtype' in DEVICE_METADATA['localhost']) and ('DualToR' in DEVICE_METADATA['localhost']['subtype']) and (port in port_names_list_extra_queues) %}
+{% elif ('subtype' in DEVICE_METADATA['localhost']) and (DEVICE_METADATA['localhost']['subtype'] == 'DualToR') and (port in port_names_list_extra_queues) %}
             "dscp_to_tc_map"  : "AZURE_UPLINK",
 {% else %}
             "dscp_to_tc_map"  : "AZURE",


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support BackendLeafRouter and BackendToRRouter.

#### How I did it
Refactored template logic to support BackendLeafRouter and BackendToRRouter, while maintaining backward compatibility with LeafRouter and ToRRouter. All type/subtype checks now use substring matching to ensure both new and legacy router type strings are handled correctly.

#### How to verify it
Run QoS tests.

#### Which release branch to backport (provide reason below if selected)
- [x] 202505

#### Tested branch (Please provide the tested image version)
202505
