### PR TITLE
platform/mellanox: add SHP parameters for MELLANOX-SPECTRUM-5 ASIC table

### DIFF
--- a/platform/mellanox/asic_table.j2
+++ b/platform/mellanox/asic_table.j2
@@ -113,7 +113,9 @@
             "cell_size": "192",
             "pipeline_latency": "19",
             "mac_phy_delay": "0.8",
-            "peer_response_time": "3.8"
+            "peer_response_time": "3.8",
+            "port_reserved_shp": "20",
+            "port_max_shp": "6144"
         },
         "OP": "SET"
     }

--- a/platform/mellanox/asic_table.j2
+++ b/platform/mellanox/asic_table.j2
@@ -1,6 +1,6 @@
 {#
     SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-    Copyright (c) 2020-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
     Apache-2.0
 
     Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Add port_reserved_shp (20) and port_max_shp (6144) to the Spectrum-5 ASIC table template for shared headroom pool configuration.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Spectrum-5 ASIC table was missing SHP (shared headroom pool) parameters. Adding `port_reserved_shp` and `port_max_shp`, enables correct buffer/headroom configuration for Spectrum-5 platforms.

#### How I did it
Added `port_reserved_shp`: "20" and `port_max_shp`: "6144" to the `ASIC_TABLE:MELLANOX-SPECTRUM-5` block in `platform/mellanox/asic_table.j2`.

#### How to verify it
1. Build a Sonic image for a Spectrum-5 platform (e.g. SN5640).
2. Apply the ASIC table config and confirm `port_reserved_shp` and `port_max_shp` are present in state_db for `ASIC_TABLE:MELLANOX-SPECTRUM-5`.
3. Verify buffer/headroom behavior on the device if applicable.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)
- [x] 202511

#### Tested branch (Please provide the tested image version)
- [x] 202511